### PR TITLE
Remove deploy to Kubernetes step

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -75,12 +75,3 @@ push-to-ecr:
       repository: pusher/k8s-spot-rescheduler
       tag: $WERCKER_GIT_COMMIT, $WERCKER_GIT_BRANCH, latest
       entrypoint: /rescheduler
-
-deploy-to-kubernetes:
-  box: busybox
-  steps:
-  - kubectl:
-      server: $KUBERNETES_MASTER
-      token: $KUBERNETES_TOKEN
-      insecure-skip-tls-verify: true
-      command: set image -n kube-system deployment k8s-spot-rescheduler k8s-spot-rescheduler=$CONTAINER_IMAGE:$WERCKER_GIT_COMMIT


### PR DESCRIPTION
We don't actually use this so it doesn't need to be there