### PR TITLE
[IS-618] - Add support for new node label schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ For example you could add the following flags to your Kubelet:
 ```
 
 ### Building
-If you wish to build the binary yourself; first make sure you have go installed and set up. Then clone this repo into your `$GOPATH` and download the dependencies using [`glide`](https://github.com/Masterminds/glide).
+If you wish to build the binary yourself; first make sure you have go installed and set up. Then clone this repo into your `$GOPATH` and download the dependencies using [`dep`](https://github.com/golang/dep).
 
 ```bash
 cd $GOPATH/src/github.com # Create this directory if it doesn't exist
 git clone git@github.com:pusher/k8s-spot-rescheduler pusher/k8s-spot-rescheduler
-glide install -v # Installs dependencies to vendor folder.
+dep ensure -v # Installs dependencies to vendor folder.
 ```
 
 Then build the code using `go build` which will produce the built binary in a file `k8s-spot-rescheduler`.

--- a/nodes/nodes_test.go
+++ b/nodes/nodes_test.go
@@ -29,12 +29,41 @@ import (
 	core "k8s.io/client-go/testing"
 )
 
+func TestIsSpotNode(t *testing.T) {
+	spotNode := createTestNodeWithLabel("fooSpotNode", 2000, map[string]string{"foo": "bar"})
+
+	SpotNodeLabel = "foo"
+	assert.True(t, isSpotNode(spotNode), "expected node with label 'foo' to be spot node")
+
+	SpotNodeLabel = "foo=bar"
+	assert.True(t, isSpotNode(spotNode), "expected node with label 'foo' and value 'bar' to be spot node")
+
+	SpotNodeLabel = "foo=baz"
+	assert.False(t, isSpotNode(spotNode), "expected node with label 'foo' and value 'bar' to not be spot node")
+}
+
+func TestIsOnDemandNode(t *testing.T) {
+	onDemandNode := createTestNodeWithLabel("fooDemandNode", 2000, map[string]string{"foo": "bar"})
+
+	OnDemandNodeLabel = "foo"
+	assert.True(t, isOnDemandNode(onDemandNode), "expected node with label 'foo' to be on demand node")
+
+	OnDemandNodeLabel = "foo=bar"
+	assert.True(t, isOnDemandNode(onDemandNode), "expected node with label 'foo' and value 'bar' to be on demand node")
+
+	OnDemandNodeLabel = "foo=baz"
+	assert.False(t, isOnDemandNode(onDemandNode), "expected node with label 'foo' and value 'bar' to not be on demand node")
+}
+
 func TestNewNodeMap(t *testing.T) {
+	OnDemandNodeLabel = "kubernetes.io/role=worker"
+	SpotNodeLabel = "kubernetes.io/role=spot-worker"
+
 	spotLabels := map[string]string{
-		SpotNodeLabel: "true",
+		"kubernetes.io/role": "spot-worker",
 	}
 	onDemandLabels := map[string]string{
-		OnDemandNodeLabel: "true",
+		"kubernetes.io/role": "worker",
 	}
 
 	nodes := []*apiv1.Node{

--- a/rescheduler_test.go
+++ b/rescheduler_test.go
@@ -70,6 +70,24 @@ func TestFindSpotNodeForPod(t *testing.T) {
 
 }
 
+func TestNodeLabelValidation(t *testing.T) {
+	onDemandLabel := "foo.bar/role=worker"
+	spotLabel := "foo.bar/node-role"
+
+	err := validateArgs(onDemandLabel, spotLabel)
+	assert.NoError(t, err)
+
+	onDemandLabel = "foo.bar/broken=worker=true"
+	err = validateArgs(onDemandLabel, spotLabel)
+	assert.EqualError(t, err, "the on demand node label is not correctly formatted: expected '<label_name>' or '<label_name>=<label_value>', but got foo.bar/broken=worker=true")
+
+	onDemandLabel = "foo.bar/role=worker"
+	spotLabel = "foo.bar/node-role=spot=fail"
+	err = validateArgs(onDemandLabel, spotLabel)
+	assert.EqualError(t, err, "the spot node label is not correctly formatted: expected '<label_name>' or '<label_name>=<label_value>', but got foo.bar/node-role=spot=fail")
+
+}
+
 func TestCanDrainNode(t *testing.T) {
 	predicateChecker := simulator.NewTestPredicateChecker()
 


### PR DESCRIPTION
In Kubernetes v1.16 the old schema `node-role.kubernetes.io/type` is being removed. This PR adds support for the new `kubernetes.io/role=type` schema.