### PR TITLE
[IS-692] Fix linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ vet: vendor
 	$(GO) vet ./...
 
 .PHONY: lint
-lint:
+lint: vendor
 	@ echo "$(GREEN)Linting code$(NC)"
 	$(LINTER) run --disable-all \
 		--exclude-use-default=false \


### PR DESCRIPTION
This adds a missing `vendor` dependency to the `lint` Makefile target